### PR TITLE
Hide Radar During Meetings

### DIFF
--- a/gui/menu.cpp
+++ b/gui/menu.cpp
@@ -25,6 +25,14 @@ namespace Menu {
 		DoorsTab::Render();
 		HostTab::Render();
 
+		if (!IsInGame())
+		{
+			State.NoClip = false;
+			State.FreeCam = false;
+			State.FollowPlayer = false;
+			State.InMeeting = false;
+		}
+
 		ImGui::EndTabBar();
 		ImGui::End();
 	}

--- a/gui/tabs/radar_tab.cpp
+++ b/gui/tabs/radar_tab.cpp
@@ -12,7 +12,14 @@ namespace RadarTab {
 
 			ImGui::Checkbox("Show Dead Bodies", &State.ShowRadar_DeadBodies);
 			ImGui::Checkbox("Show Ghosts", &State.ShowRadar_Ghosts);
+			ImGui::Checkbox("Hide Radar During Meetings", &State.HideRadar_During_Meetings);
 			ImGui::Checkbox("Right Click to Teleport", &State.ShowRadar_RightClick_Teleport);
+
+			if (!IsInGame())
+			{
+				State.InMeeting = false;
+			}
+
 			ImGui::EndTabItem();
 		}
 	}

--- a/gui/tabs/radar_tab.cpp
+++ b/gui/tabs/radar_tab.cpp
@@ -15,11 +15,6 @@ namespace RadarTab {
 			ImGui::Checkbox("Hide Radar During Meetings", &State.HideRadar_During_Meetings);
 			ImGui::Checkbox("Right Click to Teleport", &State.ShowRadar_RightClick_Teleport);
 
-			if (!IsInGame())
-			{
-				State.InMeeting = false;
-			}
-
 			ImGui::EndTabItem();
 		}
 	}

--- a/gui/tabs/self_tab.cpp
+++ b/gui/tabs/self_tab.cpp
@@ -44,13 +44,6 @@ namespace SelfTab {
 				}
 			}
 
-			if (!IsInGame())
-			{
-				State.NoClip = false;
-				State.FreeCam = false;
-				State.FollowPlayer = false;
-			}
-
 			ImGui::EndTabItem();
 		}
 	}

--- a/hooks/MeetingHud.cpp
+++ b/hooks/MeetingHud.cpp
@@ -6,11 +6,14 @@ void dMeetingHud_Awake(MeetingHud* __this, MethodInfo* method) {
 	for (auto playerData : GetAllPlayerData())
 		State.voteMonitor[playerData->fields.PlayerId] = false;
 
+	State.InMeeting = true;
+
 	MeetingHud_Awake(__this, method);
 }
 
 void dMeetingHud_Close(MeetingHud* __this, MethodInfo* method) {
 	State.voteMonitor.clear();
+	State.InMeeting = false;
 
 	MeetingHud_Close(__this, method);
 }

--- a/hooks/_hooks.cpp
+++ b/hooks/_hooks.cpp
@@ -136,7 +136,7 @@ HRESULT __stdcall hkPresent(IDXGISwapChain* pSwapChain, UINT SyncInterval, UINT 
 		Menu::Render();
 	}
 
-	if (IsInGame() && State.ShowRadar) {
+	if (IsInGame() && State.ShowRadar && (!State.InMeeting || !State.HideRadar_During_Meetings)) {
 		Radar::Render();
 	}
 

--- a/user/state.hpp
+++ b/user/state.hpp
@@ -56,7 +56,10 @@ public:
 	bool ShowRadar = false;
 	bool ShowRadar_DeadBodies = false;
 	bool ShowRadar_Ghosts = false;
+	bool HideRadar_During_Meetings = false;
 	bool ShowRadar_RightClick_Teleport = false;
+
+	bool InMeeting = false;
 
 	bool ChatAlwaysActive = false;
 	bool ReadGhostMessages = false;


### PR DESCRIPTION
Added a checkbox in the radar tab to automatically hide your radar during a meeting.