### PR TITLE
Murdering by RPC

### DIFF
--- a/AmongUsMenu.vcxproj
+++ b/AmongUsMenu.vcxproj
@@ -54,6 +54,7 @@
     <ClCompile Include="hooks\StatsManager.cpp" />
     <ClCompile Include="hooks\Vent.cpp" />
     <ClCompile Include="hooks\_hooks.cpp" />
+    <ClCompile Include="rpc\RpcMurderPlayer.cpp" />
     <ClCompile Include="rpc\RpcRepairSystem.cpp" />
     <ClCompile Include="rpc\RpcSnapTo.cpp" />
     <ClCompile Include="events\TaskCompletedEvent.cpp" />

--- a/AmongUsMenu.vcxproj.filters
+++ b/AmongUsMenu.vcxproj.filters
@@ -145,6 +145,9 @@
     <ClCompile Include="gui\tabs\self_tab.cpp">
       <Filter>gui\tabs</Filter>
     </ClCompile>
+    <ClCompile Include="rpc\RpcMurderPlayer.cpp">
+      <Filter>rpc</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="user\main.h">

--- a/gui/tabs/players_tab.cpp
+++ b/gui/tabs/players_tab.cpp
@@ -84,6 +84,13 @@ namespace PlayersTab {
 					}
 
 					if (State.selectedPlayerId > -1 && State.selectedPlayer != *Game::pLocalPlayer) {
+						if (!GetPlayerData(State.selectedPlayer)->fields.IsDead && GetPlayerData(*Game::pLocalPlayer)->fields.IsImpostor 
+							&& !GetPlayerData(*Game::pLocalPlayer)->fields.IsDead && !State.InMeeting) //Found game will black screen if murdering in a meeting
+						{
+							if (ImGui::Button("Murder"))
+								State.rpcQueue.push(new RpcMurderPlayer(*Game::pLocalPlayer, State.selectedPlayer));
+						}
+
 						if (ImGui::Button("Teleport To") && !(*Game::pLocalPlayer)->fields.inVent) {
 							State.rpcQueue.push(new RpcSnapTo(PlayerControl_GetTruePosition(State.selectedPlayer, NULL)));
 						}

--- a/rpc/RpcMurderPlayer.cpp
+++ b/rpc/RpcMurderPlayer.cpp
@@ -1,0 +1,13 @@
+#include "il2cpp-appdata.h"
+#include "_rpc.h"
+
+RpcMurderPlayer::RpcMurderPlayer(PlayerControl* murderer, PlayerControl* selected_player)
+{
+	this->murderer = murderer;
+	this->selectedPlayer = selected_player;
+}
+
+void RpcMurderPlayer::Process()
+{
+	PlayerControl_MurderPlayer(murderer, selectedPlayer, NULL);
+}

--- a/rpc/_rpc.h
+++ b/rpc/_rpc.h
@@ -38,3 +38,11 @@ public:
 	RpcCompleteTask(uint32_t taskId);
 	virtual void Process() override;
 };
+
+class RpcMurderPlayer : public RPCInterface {
+	PlayerControl* murderer;
+	PlayerControl* selectedPlayer;
+public:
+	RpcMurderPlayer(PlayerControl* murderer, PlayerControl* selected_player);
+	virtual void Process() override;
+};


### PR DESCRIPTION
The multiplayer / host requirement isn't needed, but this can be refactored into the spectate requirements afterwards.

This will warp the player to the selected player and slash them.  Found if used during a meeting a black screen will occur.