### PR TITLE
Murder / Report by RPC

### DIFF
--- a/AmongUsMenu.vcxproj
+++ b/AmongUsMenu.vcxproj
@@ -33,7 +33,7 @@
     <ClCompile Include="gui\tabs\players_tab.cpp" />
     <ClCompile Include="gui\tabs\radar_tab.cpp" />
     <ClCompile Include="gui\tabs\sabotage_tab.cpp" />
-	<ClCompile Include="gui\tabs\settings_tab.cpp" />
+    <ClCompile Include="gui\tabs\settings_tab.cpp" />
     <ClCompile Include="gui\tabs\tasks_tab.cpp" />
     <ClCompile Include="hooks\GameOptionsData.cpp" />
     <ClCompile Include="HudManager.cpp" />
@@ -56,7 +56,9 @@
     <ClCompile Include="hooks\StatsManager.cpp" />
     <ClCompile Include="hooks\Vent.cpp" />
     <ClCompile Include="hooks\_hooks.cpp" />
+    <ClCompile Include="rpc\RpcMurderPlayer.cpp" />
     <ClCompile Include="rpc\RpcRepairSystem.cpp" />
+    <ClCompile Include="rpc\RpcReportPlayer.cpp" />
     <ClCompile Include="rpc\RpcSnapTo.cpp" />
     <ClCompile Include="events\TaskCompletedEvent.cpp" />
     <ClCompile Include="gui\tabs\self_tab.cpp" />
@@ -98,7 +100,7 @@
     <ClInclude Include="gui\tabs\players_tab.h" />
     <ClInclude Include="gui\tabs\radar_tab.h" />
     <ClInclude Include="gui\tabs\sabotage_tab.h" />
-	<ClInclude Include="gui\tabs\settings_tab.h" />
+    <ClInclude Include="gui\tabs\settings_tab.h" />
     <ClInclude Include="gui\tabs\tasks_tab.h" />
     <ClInclude Include="hooks\_hooks.hpp" />
     <ClInclude Include="includes\detours\detours.h" />

--- a/AmongUsMenu.vcxproj.filters
+++ b/AmongUsMenu.vcxproj.filters
@@ -148,7 +148,13 @@
     <ClCompile Include="HudManager.cpp">
       <Filter>hooks</Filter>
     </ClCompile>
-	<ClCompile Include="gui\tabs\settings_tab.cpp" />
+    <ClCompile Include="gui\tabs\settings_tab.cpp" />
+    <ClCompile Include="rpc\RpcMurderPlayer.cpp">
+      <Filter>rpc</Filter>
+    </ClCompile>
+    <ClCompile Include="rpc\RpcReportPlayer.cpp">
+      <Filter>rpc</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="user\main.h">
@@ -283,7 +289,7 @@
     <ClInclude Include="gui\tabs\self_tab.h">
       <Filter>gui\tabs</Filter>
     </ClInclude>
-	<ClInclude Include="gui\tabs\settings_tab.h" />
+    <ClInclude Include="gui\tabs\settings_tab.h" />
   </ItemGroup>
   <ItemGroup>
     <Filter Include="user">

--- a/gui/tabs/players_tab.cpp
+++ b/gui/tabs/players_tab.cpp
@@ -73,7 +73,7 @@ namespace PlayersTab {
 							&& !GetPlayerData(*Game::pLocalPlayer)->fields.IsDead && !State.selectedPlayer.get_PlayerData()->fields.IsImpostor)
 						{	//Have not tested if murdering impostors is a ban
 							if (ImGui::Button("Warp To & Murder"))
-								State.rpcQueue.push(new RpcMurderPlayer(*Game::pLocalPlayer, State.selectedPlayer.get_PlayerData()));
+								State.rpcQueue.push(new RpcMurderPlayer(*Game::pLocalPlayer, State.selectedPlayer.get_PlayerControl()));
 						}
 					}
 

--- a/gui/tabs/players_tab.cpp
+++ b/gui/tabs/players_tab.cpp
@@ -64,9 +64,7 @@ namespace PlayersTab {
 								State.playerToFollow = State.selectedPlayer;
 							}
 						}
-					}
 
-					if (!State.selectedPlayer.is_LocalPlayer()) {
 						if (ImGui::Button("Teleport To") && !(*Game::pLocalPlayer)->fields.inVent) {
 							State.rpcQueue.push(new RpcSnapTo(PlayerControl_GetTruePosition(State.selectedPlayer.get_PlayerControl(), NULL)));
 						}

--- a/gui/tabs/players_tab.cpp
+++ b/gui/tabs/players_tab.cpp
@@ -73,7 +73,7 @@ namespace PlayersTab {
 							&& !GetPlayerData(*Game::pLocalPlayer)->fields.IsDead && !State.selectedPlayer.get_PlayerData()->fields.IsImpostor)
 						{	//Have not tested if murdering impostors is a ban
 							if (ImGui::Button("Warp To & Murder"))
-								State.rpcQueue.push(new RpcMurderPlayer(*Game::pLocalPlayer, State.selectedPlayer));
+								State.rpcQueue.push(new RpcMurderPlayer(*Game::pLocalPlayer, State.selectedPlayer.get_PlayerData()));
 						}
 					}
 

--- a/rpc/RpcMurderPlayer.cpp
+++ b/rpc/RpcMurderPlayer.cpp
@@ -1,0 +1,13 @@
+#include "il2cpp-appdata.h"
+#include "_rpc.h"
+
+RpcMurderPlayer::RpcMurderPlayer(PlayerControl* murdering_player, PlayerControl* selected_player)
+{
+	this->selectedPlayer = selected_player;
+	this->murderer = murdering_player;
+}
+
+void RpcMurderPlayer::Process()
+{
+	PlayerControl_MurderPlayer(murderer, selectedPlayer, NULL);
+}

--- a/rpc/RpcReportPlayer.cpp
+++ b/rpc/RpcReportPlayer.cpp
@@ -1,0 +1,13 @@
+#include "il2cpp-appdata.h"
+#include "_rpc.h"
+
+RpcReportPlayer::RpcReportPlayer(PlayerControl* reporting_player, GameData_PlayerInfo* selected_player)
+{
+	this->reportingPlayer = reporting_player;
+	this->selectedPlayer = selected_player;
+}
+
+void RpcReportPlayer::Process()
+{
+	PlayerControl_CmdReportDeadBody(reportingPlayer, selectedPlayer, NULL);
+}

--- a/rpc/_rpc.h
+++ b/rpc/_rpc.h
@@ -38,3 +38,19 @@ public:
 	RpcCompleteTask(uint32_t taskId);
 	virtual void Process() override;
 };
+
+class RpcMurderPlayer : public RPCInterface {
+	PlayerControl* selectedPlayer;
+	PlayerControl* murderer;
+public:
+	RpcMurderPlayer(PlayerControl* murdering_player, PlayerControl* selected_player);
+	virtual void Process() override;
+};
+
+class RpcReportPlayer : public RPCInterface {
+	PlayerControl* reportingPlayer;
+	GameData_PlayerInfo* selectedPlayer;
+public:
+	RpcReportPlayer(PlayerControl* reporting_player, GameData_PlayerInfo* selected_player);
+	virtual void Process() override;
+};


### PR DESCRIPTION
Moved call meeting outside of selecting a player (only check needed is verifying the player isn't dead)

Added checks on murdering (haven't checked to see if murdering your fellow impostor is a ban, so blocked it for now).

Consolidated checks on teleporting (don't want to teleport to a disconnected player).