### PR TITLE
Disable constant HUD activation in HudManager_Update Hook

### DIFF
--- a/hooks/HudManager.cpp
+++ b/hooks/HudManager.cpp
@@ -14,5 +14,5 @@ void dHudManager_ShowMap(HudManager* __this, Action_1_MapBehaviour_* mapAction, 
 void dHudManager_Update(HudManager* __this,  MethodInfo* method) {
 	HudManager_Update(__this, method);
 
-	HudManager_SetHudActive(__this, State.ShowHud, NULL);
+	//HudManager_SetHudActive(__this, State.ShowHud, NULL);
 }


### PR DESCRIPTION
This looks like a planned feature to hide the HUD, and can be implemented in the future.  For now it fixes the #31 issue.