### PR TITLE
Allow NoClip in Lobby

### DIFF
--- a/gui/tabs/self_tab.cpp
+++ b/gui/tabs/self_tab.cpp
@@ -43,15 +43,15 @@ namespace SelfTab {
 			ImGui::Checkbox("Unlock Vents", &State.UnlockVents);
 
 			if (ImGui::Checkbox("No Clip", &State.NoClip)) {
-				if (!IsInGame()) State.NoClip = false;
+				if (!(IsInGame() || IsInLobby())) State.NoClip = false;
 				else {
-					if (!(GetPlayerData(*Game::pLocalPlayer)->fields.IsDead)) {
-						if (State.NoClip)
-							app::GameObject_set_layer(app::Component_get_gameObject((Component*)(*Game::pLocalPlayer), NULL), app::LayerMask_NameToLayer(convert_to_string("Ghost"), NULL), NULL);
-						else
-							app::GameObject_set_layer(app::Component_get_gameObject((Component*)(*Game::pLocalPlayer), NULL), app::LayerMask_NameToLayer(convert_to_string("Players"), NULL), NULL);
-					}
+				if (!(GetPlayerData(*Game::pLocalPlayer)->fields.IsDead)) {
+					if (State.NoClip)
+						app::GameObject_set_layer(app::Component_get_gameObject((Component*)(*Game::pLocalPlayer), NULL), app::LayerMask_NameToLayer(convert_to_string("Ghost"), NULL), NULL);
+					else
+						app::GameObject_set_layer(app::Component_get_gameObject((Component*)(*Game::pLocalPlayer), NULL), app::LayerMask_NameToLayer(convert_to_string("Players"), NULL), NULL);
 				}
+			}
 			}
 			ImGui::SameLine();
 			HotKey(State.KeyBinds.Toggle_Noclip);

--- a/hooks/DirectX.cpp
+++ b/hooks/DirectX.cpp
@@ -34,7 +34,7 @@ LRESULT __stdcall dWndProc(const HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lPa
     if (KeyBindsConfig::IsReleased(State.KeyBinds.Toggle_Radar)) State.ShowRadar = !State.ShowRadar;
     if (KeyBindsConfig::IsReleased(State.KeyBinds.Toggle_Console)) State.ShowConsole = !State.ShowConsole;
     if (KeyBindsConfig::IsReleased(State.KeyBinds.Repair_Sabotage) && IsInGame()) RepairSabotage(*Game::pLocalPlayer);
-    if (KeyBindsConfig::IsReleased(State.KeyBinds.Toggle_Noclip) && IsInGame()) { State.NoClip = !State.NoClip; State.HotkeyNoClip = true; }
+    if (KeyBindsConfig::IsReleased(State.KeyBinds.Toggle_Noclip) && (IsInGame() || IsInLobby())) { State.NoClip = !State.NoClip; State.HotkeyNoClip = true; }
     if (KeyBindsConfig::IsReleased(State.KeyBinds.Close_All_Doors) && IsInGame()) State.CloseAllDoors = true;
     if (KeyBindsConfig::IsReleased(State.KeyBinds.Toggle_Zoom) && IsInGame()) State.EnableZoom = !State.EnableZoom;
     if (KeyBindsConfig::IsReleased(State.KeyBinds.Toggle_Freecam) && IsInGame()) State.FreeCam = !State.FreeCam;

--- a/hooks/InnerNetClient.cpp
+++ b/hooks/InnerNetClient.cpp
@@ -7,7 +7,6 @@ void dInnerNetClient_Update(InnerNetClient* __this, MethodInfo* method)
     if (!IsInGame()) {
         State.selectedPlayer = PlayerSelection();
         State.playerToFollow = PlayerSelection();
-        State.NoClip = false;
         State.FreeCam = false;
         State.InMeeting = false;
         State.FollowerCam = nullptr;


### PR DESCRIPTION
Needs more testing, but now noclip is disabled during loading sequences/results screen, only allowed in lobbies and games.