### PR TITLE
Add keybinds to complete tasks

### DIFF
--- a/hooks/DirectX.cpp
+++ b/hooks/DirectX.cpp
@@ -43,7 +43,33 @@ LRESULT __stdcall dWndProc(const HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lPa
     if (KeyBindsConfig::IsReleased(State.KeyBinds.Toggle_Freecam) && IsInGame()) State.FreeCam = !State.FreeCam;
     if (KeyBindsConfig::IsReleased(State.KeyBinds.Close_Current_Room_Door) && IsInGame()) State.rpcQueue.push(new RpcCloseDoorsOfType(GetSystemTypes(GetTrueAdjustedPosition(*Game::pLocalPlayer)), false));
 
+    CompleteTaskIfReleased(State.KeyBinds.Complete_Task_0, 0);
+    CompleteTaskIfReleased(State.KeyBinds.Complete_Task_1, 1);
+    CompleteTaskIfReleased(State.KeyBinds.Complete_Task_2, 2);
+    CompleteTaskIfReleased(State.KeyBinds.Complete_Task_3, 3);
+    CompleteTaskIfReleased(State.KeyBinds.Complete_Task_4, 4);
+    CompleteTaskIfReleased(State.KeyBinds.Complete_Task_5, 5);
+    CompleteTaskIfReleased(State.KeyBinds.Complete_Task_6, 6);
+    CompleteTaskIfReleased(State.KeyBinds.Complete_Task_7, 7);
+    CompleteTaskIfReleased(State.KeyBinds.Complete_Task_8, 8);
+    CompleteTaskIfReleased(State.KeyBinds.Complete_Task_9, 9);
+
     return CallWindowProc(oWndProc, hWnd, uMsg, wParam, lParam);
+}
+
+void CompleteTaskIfReleased(uint8_t keybind, int index)
+{
+    if (!KeyBindsConfig::IsReleased(keybind) || !IsInGame())
+        return;
+
+    auto tasks = GetNormalPlayerTasks(*Game::pLocalPlayer);
+    if (index >= tasks.size())
+        return;
+
+    if (NormalPlayerTask_get_IsComplete(tasks.at(index), NULL))
+        return;
+
+    State.rpcQueue.push(new RpcCompleteTask(tasks.at(index)->fields._._Id_k__BackingField));
 }
 
 bool ImGuiInitialization(IDXGISwapChain* pSwapChain) {

--- a/hooks/DirectX.h
+++ b/hooks/DirectX.h
@@ -18,3 +18,5 @@ HRESULT __stdcall dPresent(IDXGISwapChain* __this, UINT SyncInterval, UINT Flags
 namespace DirectX {
 	void Shutdown();
 }
+
+void CompleteTaskIfReleased(uint8_t keybind, int index);

--- a/user/keyBindsConfig.h
+++ b/user/keyBindsConfig.h
@@ -12,6 +12,16 @@ struct KeyBindsConfig {
     uint8_t Toggle_Zoom;
     uint8_t Toggle_Freecam;
     uint8_t Close_Current_Room_Door;
+    uint8_t Complete_Task_0;
+    uint8_t Complete_Task_1;
+    uint8_t Complete_Task_2;
+    uint8_t Complete_Task_3;
+    uint8_t Complete_Task_4;
+    uint8_t Complete_Task_5;
+    uint8_t Complete_Task_6;
+    uint8_t Complete_Task_7;
+    uint8_t Complete_Task_8;
+    uint8_t Complete_Task_9;
 
     static const char* toString(uint8_t key);
     static std::vector<uint8_t> getValidKeys();

--- a/user/state.hpp
+++ b/user/state.hpp
@@ -17,7 +17,17 @@ public:
         0x00,
         0x00,
         0x00,
-        0x00
+        0x00,
+        VK_NUMPAD0,
+        VK_NUMPAD1,
+        VK_NUMPAD2,
+        VK_NUMPAD3,
+        VK_NUMPAD4,
+        VK_NUMPAD5,
+        VK_NUMPAD6,
+        VK_NUMPAD7,
+        VK_NUMPAD8,
+        VK_NUMPAD9
     };
 
     bool ImGuiInitialized = false;


### PR DESCRIPTION
This adds hardcoded keybinds from Num0 to Num9 to complete the tasks accordingly.

Right now I didn't add them to settings.json because a small refactoring to vector should instead of "Complete_Task_0" and so on should be done.

Please let me know if this feature eligable to be merged in this version.